### PR TITLE
include_vars can only load local files

### DIFF
--- a/utilities/logic/include_vars.py
+++ b/utilities/logic/include_vars.py
@@ -14,7 +14,7 @@ author: "Benno Joy (@bennojoy)"
 module: include_vars
 short_description: Load variables from files, dynamically within a task.
 description:
-     - Loads variables from a YAML/JSON file dynamically during task runtime.  It can work with conditionals, or use host specific variables to determine the path name to load from.
+     - Loads variables from a YAML/JSON file dynamically during task runtime.  It can work with conditionals, or use host specific variables to determine the path name to load from. Only files on the machine running Ansible can be loaded.
 options:
   file:
     version_added: "2.2"


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Docs Pull Request
##### COMPONENT NAME

<!---  -->

include_vars
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.0.0
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

While obvious in retrospect include_vars can only load files from the machine running
ansible, even in tasks running against other hosts, this should be documented.

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```
N/A
```
